### PR TITLE
minor code cleaning - overview.common.read_reports 

### DIFF
--- a/rasalit/apps/overview/app.py
+++ b/rasalit/apps/overview/app.py
@@ -14,7 +14,7 @@ parser.add_argument("--folder", help="Pass the extra folder.")
 args = parser.parse_args()
 
 root_folder = args.folder
-all_conf_folders = list(read_reports(args.folder, report="intent")["config"].unique())
+all_conf_folders = list(read_reports(root_folder, report="intent")["config"].unique())
 
 df_intent = read_reports(root_folder, report="intent")
 df_entity = read_reports(root_folder, report="entity")


### PR DESCRIPTION
changing the argument of read_reports function from args.folder to root_folder in order to make it consistent with the other usages of the same function