### PR TITLE
No response_selection_report.json file scenario

### DIFF
--- a/rasalit/apps/overview/app.py
+++ b/rasalit/apps/overview/app.py
@@ -14,7 +14,7 @@ parser.add_argument("--folder", help="Pass the extra folder.")
 args = parser.parse_args()
 
 root_folder = args.folder
-all_conf_folders = list(read_reports(args.folder, report="intent")["config"].unique())
+all_conf_folders = list(read_reports(root_folder, report="intent")["config"].unique())
 
 df_intent = read_reports(root_folder, report="intent")
 df_entity = read_reports(root_folder, report="entity")

--- a/rasalit/apps/overview/common.py
+++ b/rasalit/apps/overview/common.py
@@ -11,15 +11,21 @@ def read_reports(folder, report="intent"):
         "response": "response_selection_report.json",
     }
     paths = list(pathlib.Path(folder).glob(f"*/{files[report]}"))
-    dicts = [json.loads(p.read_text())["weighted avg"] for p in paths]
-    data = [{"config": p.parts[-2], **d} for p, d in zip(paths, dicts)]
-    return pd.DataFrame(data).drop(columns=["support"]).melt("config")
+    if paths:
+        dicts = [json.loads(p.read_text())["weighted avg"] for p in paths]
+        data = [{"config": p.parts[-2], **d} for p, d in zip(paths, dicts)]
+        return pd.DataFrame(data).drop(columns=["support"]).melt("config")
+    else:
+        return pd.DataFrame()
 
 
 def remove(dataf, configs, metrics):
-    return dataf.loc[lambda d: d["config"].isin(configs)].loc[
-        lambda d: d["variable"].isin(metrics)
-    ]
+    if dataf.empty:
+        return dataf
+    else:
+        return dataf.loc[lambda d: d["config"].isin(configs)].loc[
+            lambda d: d["variable"].isin(metrics)
+        ]
 
 
 def mk_viewable(dataf):


### PR DESCRIPTION
If there is no ResponseSelector examples in the training data, rasa test nlu command does not create a response_selection_report.json. 
Rasalit assumes this file to be present rasalit.overview.common.read_reports function. The code breaks here while trying to drop the `support` column in the dataframe. It gives the following error. 
`keyError: "['support'] not found in axis`
This dataframe is empty because there was no response_selection_report.json in the folder. 

The fix here is just doing a check if such response_selection_report.json files exist. If these files are not there, rasalit.overview.common.read_reports simply returns an empty DataFrame. 